### PR TITLE
update recipe and add tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,6 @@ requirements:
   run:
     - python
     - ply
-    - decorator
-    - six
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,12 +48,11 @@ about:
   license_family: Apache
   license_file: LICENSE
   summary: Python JSONPath Next-Generation
-
   description: |
     A final implementation of JSONPath for Python that aims to be standard compliant,
     including arithmetic and binary comparison operators.
   dev_url: https://github.com/h2non/jsonpath-ng
-
+  doc_url: https://github.com/h2non/jsonpath-ng
 extra:
   recipe-maintainers:
     - shcheklein

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jsonpath-ng" %}
-{% set version = "1.5.3" %}
+{% set version = "1.6.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,28 +7,40 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: a273b182a82c1256daab86a313b937059261b5c5f8c4fa3fc38b882b344dd567
+  sha256: 086c37ba4917304850bd837aeab806670224d3f038fe2833ff593a672ef0a5fa
 
 build:
-  noarch: python
+  skip: true #[py<37]
   number: 0
   entry_points:
     - jsonpath.py=jsonpath_ng.bin.jsonpath:entry_point
-  script: {{ PYTHON }} -m pip install --no-deps . -vv
+  script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - wheel
+    - setuptools >=18.5
   run:
-    - python >=3.6
+    - python
     - ply
     - decorator
     - six
 
 test:
+  source_files:
+    - jsonpath_ng
+    - tests
   imports:
     - jsonpath_ng
+  requires:
+    - pip
+    - pytest
+  commands:
+    - pip check
+    - pytest -vv
+
 
 about:
   home: https://github.com/h2non/jsonpath-ng


### PR DESCRIPTION
jsonpath-ng 1.6.1

**Destination channel:** defaults

### Links

- [PKG-4576](https://anaconda.atlassian.net/browse/PKG-4576) 
- [Upstream repository](https://github.com/h2non/jsonpath-ng)
- [Upstream changelog/diff](https://github.com/h2non/jsonpath-ng/releases/tag/v1.6.1)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/moto-feedstock/pull/36

### Explanation of changes:
- add tests and prepare for upload to main


[PKG-4576]: https://anaconda.atlassian.net/browse/PKG-4576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ