### PR TITLE
Update recipe for py313_codesign

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jsonpath-ng" %}
-{% set version = "1.6.1" %}
+{% set version = "1.7.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 086c37ba4917304850bd837aeab806670224d3f038fe2833ff593a672ef0a5fa
+  sha256: f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c
 
 build:
   skip: true #[py<37]
-  number: 1
+  number: 0
   entry_points:
     - jsonpath.py=jsonpath_ng.bin.jsonpath:entry_point
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: true #[py<37]
-  number: 0
+  number: 1
   entry_points:
     - jsonpath.py=jsonpath_ng.bin.jsonpath:entry_point
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv


### PR DESCRIPTION
Rebuild for codesigned win-64 py313 artifacts.

update to 1.7.0
https://github.com/h2non/jsonpath-ng/tree/v1.7.0